### PR TITLE
Move files to canonical locations under /usr

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -19,19 +19,15 @@ sha256sums=('SKIP'
             'SKIP')
 
 package() {
-    install -d -m 0755 "$pkgdir/etc/pacman.d/hooks"
+    cd "$srcdir"
 
-    install -Dm644 "$srcdir/linux-modules-backup.hook" \
-        "$pkgdir/etc/pacman.d/hooks/linux-modules-backup.hook"
+    install -Dm644 -t "$pkgdir/usr/share/libalpm/hooks" \
+        "linux-modules-backup.hook" \
+        "linux-modules-restore.hook"
 
-    install -Dm644 "$srcdir/linux-modules-restore.hook" \
-        "$pkgdir/etc/pacman.d/hooks/linux-modules-restore.hook"
+    install -Dm755 -t "$pkgdir/usr/share/libalpm/scripts" \
+        "pacman-hook-linux-modules.sh"
 
-    install -Dm644 "$srcdir/cleanup-linux-modules.service" \
-        "$pkgdir/etc/systemd/system/cleanup-linux-modules.service"
-
-    install -d -m 0755 "$pkgdir/etc/pacman.d/hooks.bin"
-
-    install -Dm755 "$srcdir/pacman-hook-linux-modules.sh" \
-        "$pkgdir/etc/pacman.d/hooks.bin/pacman-hook-linux-modules.sh"
+    install -Dm644 -t "$pkgdir/usr/lib/systemd/system" \
+        "cleanup-linux-modules.service"
 }

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -21,13 +21,13 @@ sha256sums=('SKIP'
 package() {
     cd "$srcdir"
 
+    install -Dm644 -t "$pkgdir/usr/lib/systemd/system" \
+        "cleanup-linux-modules.service"
+
     install -Dm644 -t "$pkgdir/usr/share/libalpm/hooks" \
         "linux-modules-backup.hook" \
         "linux-modules-restore.hook"
 
     install -Dm755 -t "$pkgdir/usr/share/libalpm/scripts" \
         "pacman-hook-linux-modules.sh"
-
-    install -Dm644 -t "$pkgdir/usr/lib/systemd/system" \
-        "cleanup-linux-modules.service"
 }

--- a/cleanup-linux-modules.service
+++ b/cleanup-linux-modules.service
@@ -6,7 +6,7 @@ Description=Delete the kernel modules that are not owned by any a package
 
 [Service]
 Type=oneshot
-ExecStart=/etc/pacman.d/hooks.bin/pacman-hook-linux-modules.sh cleanup
+ExecStart=/usr/share/libalpm/scripts/pacman-hook-linux-modules.sh cleanup
 
 [Install]
 WantedBy=basic.target

--- a/linux-modules-backup.hook
+++ b/linux-modules-backup.hook
@@ -12,4 +12,4 @@ When = PreTransaction
 Depends = rsync
 Depends = bash
 Depends = coreutils
-Exec = /etc/pacman.d/hooks.bin/pacman-hook-linux-modules.sh backup
+Exec = /usr/share/libalpm/scripts/pacman-hook-linux-modules.sh backup

--- a/linux-modules-restore.hook
+++ b/linux-modules-restore.hook
@@ -12,4 +12,4 @@ When = PostTransaction
 Depends = rsync
 Depends = bash
 Depends = coreutils
-Exec = /etc/pacman.d/hooks.bin/pacman-hook-linux-modules.sh restore
+Exec = /usr/share/libalpm/scripts/pacman-hook-linux-modules.sh restore


### PR DESCRIPTION
Thanks for this package. I noticed that files are currently installed under `/etc`, which is generally where files that are not managed by the package manager should go. So I moved them to the canonical install locations under `/usr`.

- `/etc/pacman.d/hooks` -> `/usr/share/libalpm/hooks`
- `/etc/pacman.d/hooks.bin` -> `/usr/share/libalpm/scripts`
- `/etc/systemd/system` -> `/usr/lib/systemd/system`

This should not have any effect on the users of this package.